### PR TITLE
[TGA-60] Public Sign-Off form

### DIFF
--- a/server/requirements.in
+++ b/server/requirements.in
@@ -1,6 +1,8 @@
 gunicorn>=20.0.4,<20.1
 honcho==1.0.1
 slackclient==1.0.9
+WTForms==3.0.1
+Flask-WTF==1.2.1
 
 git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.5#egg=superdesk-core
 git+https://github.com/superdesk/superdesk-planning.git@v2.6.2#egg=superdesk-planning

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,11 +10,11 @@ arrow==0.13.0
     # via
     #   eve-elastic
     #   superdesk-core
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via redis
 authlib==0.14.3
     # via superdesk-core
-babel==2.12.1
+babel==2.13.0
     # via flask-babel
 bcrypt==3.1.7
     # via superdesk-core
@@ -26,9 +26,9 @@ blinker==1.4
     #   flask-mail
     #   raven
     #   superdesk-core
-boto3==1.28.10
+boto3==1.28.62
     # via superdesk-core
-botocore==1.31.10
+botocore==1.31.62
     # via
     #   boto3
     #   s3transfer
@@ -36,7 +36,7 @@ cachetools==5.3.1
     # via flask-oidc-ex
 celery[redis]==5.2.7
     # via superdesk-core
-cerberus==1.3.4
+cerberus==1.3.5
     # via
     #   eve
     #   superdesk-core
@@ -45,17 +45,17 @@ certifi==2023.7.22
     #   elastic-apm
     #   elasticsearch
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   bcrypt
     #   cryptography
 chardet==3.0.4
     # via superdesk-core
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 ciso8601==1.0.8
     # via eve-elastic
-click==8.1.6
+click==8.1.7
     # via
     #   celery
     #   click-didyoumean
@@ -70,25 +70,25 @@ click-repl==0.3.0
     # via celery
 croniter==0.3.37
     # via superdesk-core
-cryptography==41.0.2
+cryptography==41.0.4
     # via
     #   authlib
     #   jwcrypto
-deepdiff==6.3.1
+deepdiff==6.6.0
     # via superdesk-planning
 deprecated==1.2.14
     # via jwcrypto
 draftjs-exporter[lxml]==2.1.7
     # via superdesk-core
-ecs-logging==2.0.2
+ecs-logging==2.1.0
     # via elastic-apm
-elastic-apm[flask]==6.17.0
+elastic-apm[flask]==6.18.0
     # via superdesk-core
 elasticsearch==7.13.4
     # via eve-elastic
 eve==1.1.2
     # via superdesk-core
-eve-elastic==7.3.1
+eve-elastic==7.3.2
     # via superdesk-core
 events==0.3
     # via eve
@@ -101,6 +101,7 @@ flask==1.1.2
     #   flask-mail
     #   flask-oidc-ex
     #   flask-script
+    #   flask-wtf
     #   raven
     #   superdesk-core
 flask-babel==1.0.0
@@ -111,6 +112,8 @@ flask-oidc-ex==0.5.5
     # via superdesk-core
 flask-script==2.0.6
     # via superdesk-core
+flask-wtf==1.2.1
+    # via -r requirements.in
 future==0.18.3
     # via python-twitter
 gunicorn==20.0.4
@@ -131,6 +134,7 @@ itsdangerous==1.1.0
     # via
     #   flask
     #   flask-oidc-ex
+    #   flask-wtf
     #   superdesk-core
 jinja2==2.11.3
     # via
@@ -159,6 +163,7 @@ markupsafe==2.0.1
     # via
     #   jinja2
     #   superdesk-core
+    #   wtforms
 mongolock==1.3.4
     # via superdesk-core
 natsort==8.4.0
@@ -188,7 +193,7 @@ pymongo==3.11.4
     #   eve
     #   mongolock
     #   superdesk-core
-pyparsing==3.1.0
+pyparsing==3.1.1
     # via httplib2
 python-dateutil==2.7.5
     # via
@@ -203,7 +208,7 @@ python-magic==0.4.27
     # via superdesk-core
 python-twitter==3.5
     # via superdesk-core
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   babel
     #   celery
@@ -232,11 +237,11 @@ requests-oauthlib==1.3.1
     # via python-twitter
 rsa==4.9
     # via oauth2client
-s3transfer==0.6.1
+s3transfer==0.7.0
     # via boto3
 sgmllib3k==1.0.0
     # via feedparser
-simplejson==3.19.1
+simplejson==3.19.2
     # via eve
 six==1.16.0
     # via
@@ -254,7 +259,7 @@ superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.
     # via -r requirements.in
 superdesk-planning @ git+https://github.com/superdesk/superdesk-planning.git@v2.6.2
     # via -r requirements.in
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via superdesk-core
 tzlocal==2.1
     # via superdesk-core
@@ -272,7 +277,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.6
+wcwidth==0.2.8
     # via prompt-toolkit
 websocket-client==0.59.0
     # via slackclient
@@ -286,6 +291,10 @@ wrapt==1.15.0
     # via
     #   deprecated
     #   elastic-apm
+wtforms==3.0.1
+    # via
+    #   -r requirements.in
+    #   flask-wtf
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/server/templates/sign_off_approval_content_preview.html
+++ b/server/templates/sign_off_approval_content_preview.html
@@ -1,0 +1,125 @@
+<div class="open-editor sd-content-wrapper__authoring-content-area">
+    <div class="sd-editor__container">
+        <div class="sd-content-wrapper__main-content-area sd-main-content-grid comfort">
+            <div class="sd-main-content-grid__header">
+                <div class="subnav subnav--light">
+                    <div class="button-group button-group--end button-group--comfort" role="group">
+                        <button id="btn-provide-approval" class="btn btn--primary sd-margin-r--1">
+                            Provide Author Approval
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="sd-main-content-grid__content sd-padding--0">
+                <div class="sd-editor-content">
+                    <div class="sd-editor-content__toolbar">
+                        <div class="sd-editor-toolbar__content">
+                            <dl>
+                                <dt>First Created</dt>
+                                <dd>
+                                    <time title="{{ item.firstcreated | format_datetime(date_format="%c") }}">
+                                        {{ item.firstcreated | format_datetime(date_format="%H:%M, %d/%m/%Y") }}
+                                    </time>
+                                </dd>
+                            </dl>
+                            <dl>
+                                <dt>Last Modified</dt>
+                                <dd>
+                                    <time title="{{ item.versioncreated | format_datetime(date_format="%c") }}">
+                                        {{ item.versioncreated | format_datetime(date_format="%H:%M, %d/%m/%Y") }}
+                                    </time>
+                                </dd>
+                            </dl>
+                            <dl>
+                                <dt>Version</dt>
+                                <dd>{{ item._current_version }}</dd>
+                            </dl>
+                        </div>
+                    </div>
+                    <div class="sd-editor-content__main-container">
+                        <header id="authoring-header" class="sd-editor-content__authoring-header authoring-header--padding-medium">
+                            <div class="authoring-header__holder">
+                                {% if item.keywords %}
+                                    <div class="form__group">
+                                        {{ render_tag_list("Keywords", item.keywords) }}
+                                    </div>
+                                {% endif %}
+                                {% if item.slugline %}
+                                    <div class="form__group">
+                                        {{ render_text_input("Slugline", item.slugline) }}
+                                    </div>
+                                {% endif %}
+                                {% if item.genre %}
+                                    <div class="form__group">
+                                        {{ render_cv_items("Genre", item.genre) }}
+                                    </div>
+                                {% endif %}
+                                {% if item.anpa_category %}
+                                    <div class="form__group">
+                                        {{ render_cv_items("Categories", item.anpa_category) }}
+                                    </div>
+                                {% endif %}
+                                {% if item.subject %}
+                                    <div class="form__group">
+                                        {{ render_cv_items("Subject", item.subject) }}
+                                    </div>
+                                {% endif %}
+                                {% if item.ednote %}
+                                    <div class="form__group">
+                                        {{ render_text_input("Ed. Note", item.ednote) }}
+                                    </div>
+                                {% endif %}
+                            </div>
+
+                            <button id="btn-authoring-header-toggle" class="authoring-header__toggle">
+                                <i class="icon-chevron-up-thin"></i>
+                            </button>
+                        </header>
+
+                        <article class="content-item-preview sd-editor-content__authoring-body sd-editor-content__authoring-body-padding">
+                            <div class="content">
+                                <div class="core-content">
+                                    {% if (item.associations or {}).featuremedia %}
+                                        <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-margin-y--2">
+                                            {{ render_featuremedia_image(item) }}
+                                        </div>
+                                    {% endif %}
+                                    {% if item.headline %}
+                                        <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-margin-y--2">
+                                            {{ render_content_text("Headline", item.headline) }}
+                                        </div>
+                                    {% endif %}
+                                    {% if item.byline %}
+                                        <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-margin-y--2">
+                                            {{ render_content_text("Byline", item.byline) }}
+                                        </div>
+                                    {% endif %}
+                                    {% if item.abstract %}
+                                        <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-margin-y--2">
+                                            {{ render_html_content("Abstract", item.abstract) }}
+                                        </div>
+                                    {% endif %}
+                                    {% if (item.dateline or {}).text %}
+                                        <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-margin-y--2">
+                                            {{ render_content_text("Dateline", item.dateline.text) }}
+                                        </div>
+                                    {% endif %}
+                                    {% if item.body_html %}
+                                        <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-margin-y--2">
+                                            {{ render_html_content("Body HTML", item.body_html) }}
+                                        </div>
+                                    {% endif %}
+                                    {% if item.sign_off %}
+                                        <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-margin-y--2">
+                                            {{ render_content_text("Sign Off", item.sign_off) }}
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/server/templates/sign_off_approval_modal.html
+++ b/server/templates/sign_off_approval_modal.html
@@ -1,0 +1,190 @@
+<div id="modal-container" style="display: none">
+    <div>
+        <div class="modal__backdrop fade in"></div>
+        <div class="modal modal--large" style="display: block;">
+            <div class="modal__dialog">
+                <div class="modal__content">
+                    <div class="modal__header modal__header--flex">
+                        <h3 class="modal__heading">Sign Off</h3>
+                        <button class="icn-btn">
+                            <i id="btn-footer-close-modal" class="icon-close-small"></i>
+                        </button>
+                    </div>
+                    <div class="modal__body">
+                        {% if form_errors %}
+                            <h3>An error occurred while processing your request.</h3>
+                            <ul>
+                            {% for field, errors in form_errors.items() %}
+                                <li><strong>{{ field }}:</strong> {{ ','.join(errors) }}</li>
+                            {% endfor %}
+                            </ul>
+                        {% else %}
+                            <form id="form-submit-approval" method="post">
+                                {{ form.csrf_token }}
+                                {{ form.item_id(value=item._id) }}
+                                {{ form.user_id(value=data.author_id) }}
+                                {{ form.version_signed(value=item._current_version) }}
+
+                                <div class="form__group">
+                                    <div class="form__row">
+                                        <div class="form-label form-label--block">
+                                            Funding Source
+                                        </div>
+                                        <p class="sd-margin--0">
+                                            What is the funding source for the research undertaken by you and
+                                            being referred to in your contribution?<br/>
+                                            If no research or not your research then state N/A.
+                                        </p>
+                                        <div class="sd-input sd-input--medium">
+                                            <div class="sd-input__input-container">
+                                                {{ form.funding_source(class="sd-input__input", id="funding_source", required="true") }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="form__group">
+                                    <div class="form__row">
+                                        <div class="form-label form-label--block">
+                                            Affiliation
+                                        </div>
+                                        <span>
+                                            Do you have any financial, personal or political affiliation or
+                                            other that may be perceived as a conflict in connection with
+                                            your contribution?
+                                        </span>
+                                        <div class="sd-input sd-input--medium">
+                                            <div class="sd-input__input-container">
+                                                {{ form.affiliation(class="sd-input__input", id="affiliation", required="true") }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="form__group">
+                                    <div class="form__row">
+                                        <p class="sd-margin--0">
+                                            We collect the above information in order to enable 360info to
+                                            adhere to its charter by being transparent about funding and
+                                            affiliations.
+                                        </p>
+                                    </div>
+                                </div>
+
+                                <div class="form__group">
+                                    <div class="form__row">
+                                        <div class="form-label form-label--block">
+                                            Consent
+                                        </div>
+                                        <span class="sd-check-new__wrapper">
+                                            {{ form.consent_publish(class="sd-check-new__input", id="input-consent-publish", type="checkbox", required="true") }}
+                                            <span class="sd-check-new"></span>
+                                            <label>
+                                                I consent to the personal information that I provide for 360info being used for the purposes of publishing my contribution.
+                                            </label>
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="form__group">
+                                    <div class="form__row">
+                                        <span class="sd-check-new__wrapper">
+                                            {{ form.consent_disclosure(class="sd-check-new__input", id="input-consent-public", type="checkbox", required="true") }}
+                                            <span class="sd-check-new"></span>
+                                            <label>
+                                                I consent to the personal information that I provide for 360info being disclosed to the public on my published contribution.
+                                            </label>
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div class="form__group">
+                                    <div class="form__row">
+                                        <p class="sd-margin--0">
+                                            360info values the privacy of every individual’s personal information
+                                            and is committed to the protection of that information from
+                                            unauthorised use and disclosure except where permitted by law.
+                                            For more information about Data Protection and Privacy at Monash
+                                            University please see our
+                                            <a
+                                                href="https://www.monash.edu/__data/assets/pdf_file/0003/790086/Privacy.pdf"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                            >
+                                                Data Protection and Privacy Procedure.
+                                            </a>
+                                            If you have any questions about how 360info is collecting and
+                                            handling your personal information, please contact our Data
+                                            Protection and Privacy Office at
+                                            <a
+                                                href="mailto:dataprotectionofficer@monash.edu"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                            >
+                                                dataprotectionofficer@monash.edu
+                                            </a>.
+                                        </p>
+                                    </div>
+                                </div>
+                            </form>
+                        {% endif %}
+                    </div>
+                    <div class="modal__footer" style="justify-content: flex-end">
+                        <div class="sd-d-flex">
+                            <div class="button-group button-group--end button-group--comfort" role="group">
+                                <button id="btn-cancel-approval-modal" type="reset" class="btn" form="form-submit-approval">Cancel</button>
+                                <button id="btn-approve" class="btn btn--primary" type="submit" form="form-submit-approval" disabled>Approve</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    const btnProvideApproval = document.getElementById('btn-provide-approval');
+    const modalContainer = document.getElementById('modal-container');
+    const btnFooterCloseModal = document.getElementById('btn-footer-close-modal');
+    const btnCancelApprovalModal = document.getElementById('btn-cancel-approval-modal');
+    const btnApprove = document.getElementById('btn-approve');
+    const authoringHeader = document.getElementById('authoring-header');
+    const btnAuthoringHeaderToggle = document.getElementById('btn-authoring-header-toggle');
+
+    function showModal() {
+        modalContainer.style.display = 'block';
+    }
+    function hideModal() {
+        modalContainer.style.display = 'none';
+    }
+
+    btnProvideApproval.addEventListener('click', showModal);
+    btnFooterCloseModal.addEventListener('click', hideModal);
+    btnCancelApprovalModal.addEventListener('click', hideModal);
+
+    btnAuthoringHeaderToggle.addEventListener('click', function() {
+        if (authoringHeader.classList.contains('authoring-header--collapsed')) {
+            authoringHeader.classList.remove('authoring-header--collapsed');
+        } else {
+            authoringHeader.classList.add('authoring-header--collapsed');
+        }
+    });
+
+    {% if form_errors %}
+        showModal();
+    {% else %}
+        const inputConsentPublish = document.getElementById('input-consent-publish');
+        const inputConsentPublic = document.getElementById('input-consent-public');
+
+        function onConsentChanged() {
+            if (inputConsentPublish.checked === true && inputConsentPublic.checked === true) {
+                btnApprove.removeAttribute('disabled');
+            } else {
+                btnApprove.setAttribute('disabled', '');
+            }
+        }
+
+        inputConsentPublish.addEventListener('change', onConsentChanged);
+        inputConsentPublic.addEventListener('change', onConsentChanged);
+    {% endif %}
+</script>

--- a/server/templates/sign_off_approval_submitted.html
+++ b/server/templates/sign_off_approval_submitted.html
@@ -8,22 +8,6 @@
         <link rel="icon" type="image/x-icon" href="/images/favicon.ico" />
         <link rel="stylesheet" type="text/css" href="{{ css_file_path }}" />
     </head>
-    <style>
-    .content-item-preview .content .core-content img {
-        max-width: 100%;
-    }
-
-    .p-chips-multiple-container {
-        min-height: 32px;
-    }
-
-    .html-preview {
-        padding: 1.6rem 1.6rem 0 1.6rem;
-        min-height: 5.6rem;
-        border: 2px solid var(--color-input-border);
-        border-radius: var(--b-radius--large);
-    }
-    </style>
     <body>
         <div class="sd-page-grid">
             <header class="sd-top-menu">
@@ -42,29 +26,12 @@
                         </li>
                     </ul>
                 </div>
-
-                {% if token_error %}
-                    <div class="sd-margin-t--1 sd-margin-l--2">
-                        <h1>An error has occurred.</h1>
-                        {% if token_error == "no_token" %}
-                            <p class="lead">Token not provided, invalid URL</p>
-                        {% elif token_error == "expired" %}
-                            <p class="lead">Token has expired. Please contact your administrator.</p>
-                        {% elif token_error == "invalid" %}
-                            <p class="lead">Invalid token. Please make sure you have the correct URL.</p>
-                        {% else %}
-                            <p class="lead">Failed to process token: {{ token_error }}</p>
-                        {% endif %}
-                    </div>
-                {% else %}
-                    {% include "sign_off_approval_content_preview.html" %}
-                {% endif %}
-
+                <div class="sd-margin-t--1 sd-margin-l--2">
+                    <h3>Congratulations</h3>
+                    <p class="lead">Your approval has been sent.</p>
+                </div>
             </section>
             <footer class="sd-bottom-bar"></footer>
-            {% if not token_error %}
-                {% include "sign_off_approval_modal.html" %}
-            {% endif %}
         </div>
     </body>
 </html>

--- a/server/tests/sign_off_request_test.py
+++ b/server/tests/sign_off_request_test.py
@@ -35,6 +35,10 @@ class SignOffRequestTestCase(TestCase):
                     "guid": "tag:example.com,0000:newsml_BRE9A605",
                     "slugline": "slugger-info",
                     "headline": "Header Of The Informational Article",
+                    "body_html": "<p>The story so far.</p>",
+                    "genre": [{"name": "Article", "qcode": "Article"}],
+                    "anpa_category": [{"qcode": "i", "name": "International News"}],
+                    "subject": [{"qcode": "17004000", "name": "Statistics"}, {"qcode": "04001002", "name": "Weather"}],
                 }
             ],
         )[0]
@@ -78,8 +82,7 @@ class SignOffRequestTestCase(TestCase):
             assert response.status_code == 200
             response_text = response.get_data(as_text=True)
 
-            assert "Token Valid" in response_text
-            assert item_id in response_text
+            assert "Header Of The Informational Article" in response_text
             current_user_id = 0 if "foo@foobar.org" in email_sent.recipients else 1
             assert str(user_ids[current_user_id]) in response_text
 

--- a/server/tga/sign_off/__init__.py
+++ b/server/tga/sign_off/__init__.py
@@ -1,6 +1,21 @@
 from superdesk.factory.app import SuperdeskEve
+
 from .sign_off_requests import sign_off_request_bp
+from .template_globals import (
+    render_text_input,
+    render_content_text,
+    render_html_content,
+    render_tag_list,
+    render_cv_items,
+    render_featuremedia_image,
+)
 
 
 def init_app(app: SuperdeskEve):
     app.register_blueprint(sign_off_request_bp)
+    app.add_template_global(render_text_input)
+    app.add_template_global(render_content_text)
+    app.add_template_global(render_html_content)
+    app.add_template_global(render_tag_list)
+    app.add_template_global(render_cv_items)
+    app.add_template_global(render_featuremedia_image)

--- a/server/tga/sign_off/form.py
+++ b/server/tga/sign_off/form.py
@@ -1,0 +1,15 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, BooleanField, HiddenField
+from wtforms.validators import DataRequired
+
+
+class UserSignOffForm(FlaskForm):
+    item_id = HiddenField("Item Id")
+    user_id = HiddenField("User Id")
+    version_signed = HiddenField("Item Version Signed")
+
+    funding_source = StringField("Funding Source", validators=[DataRequired()])
+    affiliation = StringField("Affiliation", validators=[DataRequired()])
+
+    consent_publish = BooleanField("Consent Publish", validators=[DataRequired()])
+    consent_disclosure = BooleanField("Consent Disclosure", validators=[DataRequired()])

--- a/server/tga/sign_off/template_globals.py
+++ b/server/tga/sign_off/template_globals.py
@@ -1,0 +1,107 @@
+from typing import List
+from typing_extensions import TypedDict
+
+
+def get_input_id_from_label(label: str) -> str:
+    return "input_" + label.replace(" ", "_").lower()
+
+
+def render_text_input(label: str, value: str):
+    input_id = get_input_id_from_label(label)
+
+    return f"""
+<div class="form__item">
+    <div class="sd-input sd-input--medium">
+        <label class="sd-input__label" for="{input_id}">{label}</label>
+        <div class="sd-input__input-container">
+            <input id="{input_id}" type="text" class="sd-input__input" disabled value="{value}" />
+        </div>
+    </div>
+</div>
+"""
+
+
+def render_content_text(label: str, value: str):
+    input_id = get_input_id_from_label(label)
+
+    return f"""
+<div class="sd-input sd-input--x-large sd-input--boxed-style sd-input--boxed-label">
+    <label class="sd-input__label sd-input__label--boxed" for="{input_id}">
+        {label}
+    </label>
+    <div class="sd-input__input-container">
+        <input id="{input_id}" class="sd-input__input" type="text" disabled value="{value}" />
+    </div>
+</div>
+"""
+
+
+def render_html_content(label: str, value: str):
+    input_id = get_input_id_from_label(label)
+
+    return f"""
+<div class="sd-input sd-input--x-large sd-input--boxed-style sd-input--boxed-label">
+    <label class="sd-input__label sd-input__label--boxed" for="{input_id}">
+        {label}
+    </label>
+    <div class="sd-input__input-container">
+        <div id="{input_id}" class="html-preview">
+            {value}
+        </div>
+    </div>
+</div>
+"""
+
+
+class CVItem(TypedDict):
+    name: str
+
+
+def render_tag_list(label: str, values: List[str]):
+    input_id = get_input_id_from_label(label)
+    value_list = "".join(
+        [
+            f"""<li class="p-chips-token p-highlight"><span class="p-chips-token-label">{value}</span></li>"""
+            for value in values
+        ]
+    )
+    chip_classes = "p-chips p-component p-inputwrapper tags-input--multi-select sd-input__input  p-inputwrapper-filled"
+
+    return f"""
+<div class="form__item">
+    <div class="sd-input sd-input--medium">
+        <label class="sd-input__label" for="{input_id}">{label}</label>
+        <div class="sd-input__input-container">
+            <div class="{chip_classes}" style="cursor: not-allowed !important;">
+                <ul id="{input_id}" class="p-inputtext p-chips-multiple-container">
+                    {value_list}
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+"""
+
+
+def render_featuremedia_image(item):
+    featuremedia = item["associations"]["featuremedia"]
+    image_url = featuremedia["renditions"]["viewImage"]["href"]
+    alt_text = featuremedia["alt_text"]
+
+    return f"""
+<div class="sd-input sd-input--x-large sd-input--boxed-style sd-input--boxed-label">
+    <label class="sd-input__label sd-input__label--boxed" for="input_featuremedia">
+        Featuremedia
+    </label>
+    <div class="sd-input__input-container">
+        <figure>
+            <img id="input_featuremedia" src="{image_url}" alt="{alt_text}" />
+            <figcaption>{alt_text}</figcaption>
+        </figure>
+    </div>
+</div>
+"""
+
+
+def render_cv_items(label: str, values: List[CVItem]):
+    return render_tag_list(label, [value["name"] for value in values])

--- a/server/tga/sign_off/utils.py
+++ b/server/tga/sign_off/utils.py
@@ -1,0 +1,124 @@
+from typing import Dict, List, Optional, Any
+import pathlib
+from copy import deepcopy
+import re
+from time import time
+
+from authlib.jose import JsonWebToken
+from bson import ObjectId
+from bson.errors import InvalidId
+from flask import g, current_app as app
+from flask_babel import _
+
+from superdesk import get_resource_service
+from superdesk.errors import SuperdeskApiError
+from superdesk.utc import utcnow
+from superdesk.notification import push_notification
+
+from .form import UserSignOffForm
+
+
+JWT_ALGORITHM = "HS256"
+
+
+def get_css_filename():
+    try:
+        dist_path = pathlib.Path(pathlib.Path(__file__).parent.parent.parent.parent, "client/dist")
+        css_filename = [f.name for f in dist_path.glob("app.bundle.*.css")][0]
+        return f"/{css_filename}"
+    except (IndexError, ValueError):
+        return "/app.bundle.css"
+
+
+def modify_asset_urls(item, author_id: ObjectId):
+    pattern = re.compile('\/api\/upload-raw\/(.*?)"')
+    new_body_html = item["body_html"]
+    url_prefix = "/api/upload-raw/"
+    url_prefix_len = len(url_prefix)
+
+    for asset_filename in re.findall(pattern, item["body_html"]):
+        asset_token = gen_jwt_for_approval_request(asset_filename, author_id, "upload-raw", token_expiration=3600)
+        new_body_html = new_body_html.replace(
+            url_prefix + asset_filename, f"/api/sign_off_requests/upload-raw/{asset_token}"
+        )
+
+    item["body_html"] = new_body_html
+
+    for key, association in (item.get("associations") or {}).items():
+        for size_name, rendition in (association.get("renditions") or {}).items():
+            rendition_href = rendition["href"]
+            asset_filename = rendition_href[rendition_href.index(url_prefix) + url_prefix_len :]
+            asset_token = gen_jwt_for_approval_request(asset_filename, author_id, "upload-raw", token_expiration=3600)
+            rendition["href"] = rendition_href.replace(
+                url_prefix + asset_filename, f"/api/sign_off_requests/upload-raw/{asset_token}"
+            )
+
+
+def update_item_publish_approval(item: Dict[str, Any], form: UserSignOffForm):
+    data = deepcopy(item.get("extra") or {})
+    data["publish_sign_off"] = {
+        "user_id": ObjectId(form.user_id.data),
+        "funding_source": form.funding_source.data,
+        "affiliation": form.affiliation.data,
+        "consent_publish": form.consent_publish.data,
+        "consent_disclosure": form.consent_disclosure.data,
+        "sign_date": utcnow(),
+        "version_signed": form.version_signed.data,
+    }
+
+    g.user = get_resource_service("users").find_one(req=None, _id=ObjectId(form.user_id.data))
+    updates = {"extra": data}
+    get_resource_service("archive").system_update(item["_id"], updates, item)
+    get_resource_service("archive_history").on_item_updated(updates, item, "author_approval")
+    del g.user
+
+    push_notification(
+        "author_approval:updated", extension="tga-sign-off", item_id=item["_id"], new_sign_off=data["publish_sign_off"]
+    )
+
+
+def get_item_from_token_data(data):
+    archive_service = get_resource_service("archive")
+    item_id: str = data.get("item_id")
+    if not item_id:
+        raise SuperdeskApiError.badRequestError(_("item_id field is required"))
+    item = archive_service.find_one(req=None, _id=item_id)
+    if not item:
+        raise SuperdeskApiError.notFoundError(_("Content not found"))
+
+    return item
+
+
+def get_users_from_token_data(data) -> List[Dict[str, Any]]:
+    users_service = get_resource_service("users")
+    try:
+        authors: List[ObjectId] = [ObjectId(authorId) for authorId in data.get("authors") or []]
+    except InvalidId:
+        raise SuperdeskApiError.badRequestError(_("authors field must be a list of ObjectIds"))
+    if not len(authors):
+        raise SuperdeskApiError.badRequestError(_("authors field is required"))
+
+    users = []
+    for user_id in authors:
+        user = users_service.find_one(req=None, _id=user_id)
+        if not user:
+            raise SuperdeskApiError.notFoundError(_("User not found"))
+        users.append(user)
+
+    return users
+
+
+def gen_jwt_for_approval_request(item_id: str, author_id: ObjectId, scope: str, token_expiration: Optional[int] = None):
+    header = {"alg": JWT_ALGORITHM}
+    payload = {
+        "iss": "Superdesk Author Approvals",
+        "iat": int(time()),
+        "exp": int(time() + (token_expiration or app.config["SIGN_OFF_REQUESTS_EXPIRATION"])),
+        "scope": scope,
+        "author_id": str(author_id),
+        "item_id": item_id,
+    }
+
+    token = JsonWebToken([JWT_ALGORITHM]).encode(header, payload, app.config["SIGN_OFF_REQUESTS_SHARED_SECRET"])
+
+    return token.decode("UTF-8")


### PR DESCRIPTION
@thecalcc I have not modified the schema for the existing author sign off (so the existing sign off front-end extension still works as is).

Also, a websocket notification is sent to the front-end when someone signed off on an article, so the front-end can update the form if the item is currently open. (see https://github.com/MarkLark86/superdesk-tga/blob/TGA-60/server/tga/sign_off/utils.py#L76).

You should be able to use the `addWebsocketMessageListener` from the SuperdeskAPI when registering the `tga-sign-off` extension, listening to message `author_approval:updated` with the following attributes included in the message:
```ts
interface SignOffUpdateMessage {
    item_id: string;
    new_sign_off_data: {
        user_id: string;
        funding_source: string;
        affiliation: string;
        consent_publish: boolean;
        consent_disclosure: boolean;
        sign_date: string; // datetime value, in UTC
        version_signed: number; // the `_current_version` value at the time of signing
    };
}
```