### PR TITLE
[SDESK-7161] update cores to fix resending to Newshub

### DIFF
--- a/server/requirements.in
+++ b/server/requirements.in
@@ -2,6 +2,6 @@ gunicorn>=20.0.4,<20.1
 honcho==1.0.1
 slackclient==1.0.9
 
-git+https://github.com/superdesk/superdesk-core.git@v2.6.5#egg=superdesk-core
+git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.8#egg=superdesk-core
 git+https://github.com/superdesk/superdesk-planning.git@v2.6.3-rc1#egg=superdesk-planning
 git+https://github.com/superdesk/superdesk-analytics@v2.6.0#egg=superdesk-analytics

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
 arrow==0.13.0
     # via
@@ -14,7 +14,7 @@ async-timeout==4.0.3
     # via redis
 authlib==0.14.3
     # via superdesk-core
-babel==2.13.1
+babel==2.14.0
     # via flask-babel
 bcrypt==3.1.7
     # via superdesk-core
@@ -26,9 +26,9 @@ blinker==1.4
     #   flask-mail
     #   raven
     #   superdesk-core
-boto3==1.28.72
+boto3==1.34.20
     # via superdesk-core
-botocore==1.31.72
+botocore==1.34.20
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ cerberus==1.3.5
     # via
     #   eve
     #   superdesk-core
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   elastic-apm
     #   elasticsearch
@@ -53,7 +53,7 @@ cffi==1.16.0
     #   cryptography
 chardet==3.0.4
     # via superdesk-core
-charset-normalizer==3.3.1
+charset-normalizer==3.3.2
     # via requests
 ciso8601==1.0.8
     # via eve-elastic
@@ -72,11 +72,11 @@ click-repl==0.3.0
     # via celery
 croniter==0.3.37
     # via superdesk-core
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   authlib
     #   jwcrypto
-deepdiff==6.6.1
+deepdiff==6.7.1
     # via superdesk-planning
 deprecated==1.2.14
     # via jwcrypto
@@ -86,7 +86,7 @@ draftjs-exporter[lxml]==2.1.7
     #   superdesk-core
 ecs-logging==2.1.0
     # via elastic-apm
-elastic-apm[flask]==6.19.0
+elastic-apm[flask]==6.20.0
     # via
     #   elastic-apm
     #   superdesk-core
@@ -98,7 +98,7 @@ eve-elastic==7.3.2
     # via superdesk-core
 events==0.3
     # via eve
-feedparser==6.0.10
+feedparser==6.0.11
     # via superdesk-core
 flask==1.1.2
     # via
@@ -131,7 +131,7 @@ httplib2==0.22.0
     # via oauth2client
 icalendar==4.0.9
     # via superdesk-planning
-idna==3.4
+idna==3.6
     # via requests
 itsdangerous==1.1.0
     # via
@@ -147,7 +147,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jwcrypto==1.5.0
+jwcrypto==1.5.1
     # via
     #   flask-oidc-ex
     #   python-jwt
@@ -177,9 +177,9 @@ ordered-set==4.1.0
     # via deepdiff
 pillow==9.2.0
     # via superdesk-core
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.43
     # via click-repl
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   ldap3
     #   oauth2client
@@ -203,7 +203,7 @@ python-dateutil==2.7.5
     #   croniter
     #   icalendar
     #   superdesk-core
-python-jwt==4.0.0
+python-jwt==4.1.0
     # via flask-oidc-ex
 python-magic==0.4.27
     # via superdesk-core
@@ -240,7 +240,7 @@ requests-oauthlib==1.3.1
     # via python-twitter
 rsa==4.9
     # via oauth2client
-s3transfer==0.7.0
+s3transfer==0.10.0
     # via boto3
 sgmllib3k==1.0.0
     # via feedparser
@@ -258,11 +258,11 @@ slackclient==1.0.9
     # via -r requirements.in
 superdesk-analytics @ git+https://github.com/superdesk/superdesk-analytics@v2.6.0
     # via -r requirements.in
-superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@v2.6.5
+superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.8
     # via -r requirements.in
 superdesk-planning @ git+https://github.com/superdesk/superdesk-planning.git@v2.6.3-rc1
     # via -r requirements.in
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via superdesk-core
 tzlocal==2.1
     # via superdesk-core
@@ -275,12 +275,12 @@ urllib3==1.25.11
     #   elasticsearch
     #   requests
     #   superdesk-core
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.8
+wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==0.59.0
     # via slackclient

--- a/server/settings.py
+++ b/server/settings.py
@@ -196,3 +196,6 @@ CONTENTAPI_INSTALLED_APPS = [module for module in CONTENTAPI_INSTALLED_APPS if m
     "tga.content_api.items",
     "tga.content_api.author_profiles",
 ]
+
+# Disable purging of publish queue
+PUBLISH_QUEUE_EXPIRY_MINUTES = 0


### PR DESCRIPTION
Also disabled `PUBLISH_QUEUE_EXPIRY_MINUTES`, as they do not publish enough content for this to be an issue (~1,500 in `published` in the last year).