### PR TITLE
[TGA-109] fix: AuthorProfile save fails if first/last names are None

### DIFF
--- a/server/tga/author_profiles.py
+++ b/server/tga/author_profiles.py
@@ -54,7 +54,7 @@ def _content_profile_contains_custom_profile_id(custom_fields: List[Dict[str, An
 
 def _set_article_fields(updates: Dict[str, Any]):
     extra = updates.get("extra") or {}
-    updates["slugline"] = extra.get("profile_first_name", "") + " " + extra.get("profile_last_name", "")
+    updates["slugline"] = (extra.get("profile_first_name") or "") + " " + (extra.get("profile_last_name") or "")
 
     if not updates.get("headline"):
         updates["headline"] = "Author Profile"


### PR DESCRIPTION
When the input field is emptied in the front-end, it changes the value to `null` or `None. So make sure to populate slugline with a string